### PR TITLE
Update adio.tmuxcolors for tmux >=2.9

### DIFF
--- a/tmux/adio.tmuxcolors
+++ b/tmux/adio.tmuxcolors
@@ -3,41 +3,30 @@
 #
 
 # default statusbar colors
-set-option -g status-fg colour250
-set-option -g status-bg colour234
-set-option -g status-attr default
+set-option -g status-style fg=colour250,bg=colour234
 
 # default left statusbar colors
-set-option -g status-left-fg colour250
-set-option -g status-left-bg default
-set-option -g status-left-attr default
+set-option -g status-left-style fg=colour250
 
 # default right statusbar colors
-set-option -g status-right-fg colour240
-set-option -g status-right-bg default
-set-option -g status-right-attr default
+set-option -g status-right-style fg=colour240
 
 # default window title colors
-set-window-option -g window-status-fg colour240
-set-window-option -g window-status-bg default
+set-option -g window-status-style fg=colour240
 
 # active window title colors
-set-window-option -g window-status-current-fg colour252
-set-window-option -g window-status-current-bg default
-set-window-option -g window-status-current-attr default
+set-option -g window-status-current-style fg=colour252
 
 # pane border
-set-option -g pane-border-fg colour235
-set-option -g pane-active-border-fg colour235
+set-option -g pane-border-style fg=colour235
+set-option -g pane-active-border-style fg=colour235
 
 # message text
-set-option -g message-fg colour232
-set-option -g message-bg colour32
+set-option -g message-style fg=colour232,bg=colour32
 
 # pane number display
-# set-option -g display-panes-active-colour colour32
-# set-option -g display-panes-colour colour166
+set-option -g display-panes-active-colour colour32
+set-option -g display-panes-colour colour166
 
-set-option -g mode-fg colour232
-set-option -g mode-bg colour32
+set-option -g mode-style fg=colour232,bg=colour32
 


### PR DESCRIPTION
The attributes used are older and not documented. In tmux 2.9 they were
removed entirely, and now tmux prints a warning instead:

```
invalid option: status-fg
```

The original issue raised is tmux/tmux#1689.

Also: the `adio-theme` looks awesome!